### PR TITLE
deps: patch postcss XSS (GHSA-qx2v-qp2m-jg93) + tailwindcss 4.2.4 (#16)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "react-dom": "19.2.5"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
+    "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -37,7 +37,10 @@
     "eslint-config-next": "^16.2.4",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.2.4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.12"
   }
 }


### PR DESCRIPTION
Closes #16 (Phase 1).

## Summary
- Adds `overrides.postcss: ^8.5.12` to `package.json` to resolve **GHSA-qx2v-qp2m-jg93** (PostCSS XSS via unescaped `</style>` in CSS stringify output, CVSS 6.1, moderate). Vulnerable copies were pulled transitively at root (`8.5.9`) and nested under `next` (`8.4.31`); `npm audit fix` proposed a regressive `next` downgrade so an override is the correct remediation.
- Bumps `tailwindcss` and `@tailwindcss/postcss` from `^4` to `^4.2.4` (patch bumps surfaced by `npm outdated`).

No major version bumps in this PR — see #16 for the queued majors (TypeScript 6, ESLint 10, eslint-plugin-react-hooks 7, @types/node 25), which need a separate plan + approval.

## Local verification (Node 22.22.2 / npm 10.9.7)
After `npm install`:
- `npm audit` → **found 0 vulnerabilities** (was 2 moderate)
- `npm test` → 1/1 passing
- `npm run build` → green (compiled, TS clean, static export OK)

Confirmed `node_modules/postcss` resolves to **8.5.12** and the nested `node_modules/next/node_modules/postcss` is removed by the override.

## Note on lockfile
`package-lock.json` should be regenerated by running `npm install` on this branch (or via your CI's lockfile job). The repo's transport channel rejected the lockfile push from this environment (503 on `git-receive-pack` — unrelated to repo state). The override declared in `package.json` is the binding fix; once `npm install` runs the lockfile will record `postcss@8.5.12` everywhere. If you'd prefer, I can attach the regenerated lockfile via a follow-up commit pushed from elsewhere.

## Test plan
- [ ] Run `npm install` on this branch and confirm `npm audit` reports 0 vulnerabilities
- [ ] Run `npm test` and `npm run build` in CI
- [ ] Commit the regenerated `package-lock.json`

---
_Generated by [Claude Code](https://claude.ai/code/session_015QBuzFVUsADUzGcmpSRrpn)_