### PR TITLE
chore(deps): floor bumps — lucide-react ^1.14.0, postcss override ^8.5.13 (audit 2026-05-02)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@next/mdx": "^16.2.4",
     "@types/mdx": "^2.0.13",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "lucide-react": "^1.11.0",
+    "lucide-react": "^1.14.0",
     "next": "16.2.4",
     "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
@@ -41,6 +41,6 @@
     "typescript": "^5"
   },
   "overrides": {
-    "postcss": "^8.5.12"
+    "postcss": "^8.5.13"
   }
 }


### PR DESCRIPTION
## Summary

Auto-applied minor/patch floor bumps from the 2026-05-02 dependency audit (#18).

- `lucide-react`: `^1.11.0` → `^1.14.0` (minor)
- `overrides.postcss`: `^8.5.12` → `^8.5.13` (patch — keeps GHSA-qx2v-qp2m-jg93 cleared)

Both ranges already resolved to these versions via existing `^` carets, so installed tree / `package-lock.json` is unchanged at HEAD. This commit just brings the declared floors into line. CI will refresh `package-lock.json` on `npm install` and surface any drift.

`npm audit` returns 0 vulnerabilities. No major bumps applied — `eslint` / `typescript` / `@types/node` / `eslint-plugin-react-hooks` remain blocked pending owner approval (#9 / #10 / #14).

## Test plan

- [ ] `npm install` succeeds
- [ ] `npm audit` returns 0 vulnerabilities
- [ ] `npm run lint` clean
- [ ] `npm test` passes (Jest)
- [ ] `npm run build` succeeds

Closes #18 (auto-apply portion).

_Generated by Claude Code._

---
_Generated by [Claude Code](https://claude.ai/code/session_01N587TgP9aEjWtCWwULGCmd)_