### PR TITLE
chore(deps): security patch — next 16.2.4→16.2.6, react 19.2.5→19.2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,15 +14,15 @@
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@next/mdx": "^16.2.4",
+    "@next/mdx": "^16.2.6",
     "@types/mdx": "^2.0.13",
     "eslint-plugin-react-hooks": "^5.2.0",
     "lucide-react": "^1.14.0",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
-    "react": "19.2.5",
-    "react-dom": "19.2.5"
+    "react": "19.2.6",
+    "react-dom": "19.2.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.2.4",
@@ -34,7 +34,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "^16.2.4",
+    "eslint-config-next": "^16.2.6",
     "jest": "^30.3.0",
     "jest-environment-jsdom": "^30.3.0",
     "tailwindcss": "^4.2.4",


### PR DESCRIPTION
Closes #25.
Splits the major-version `eslint-plugin-react-hooks` bump out to #26 (awaiting plan approval).

## Why now (security)
Next.js 16.2.5 / 16.2.6 ship **7 HIGH + 4 moderate + 2 low** advisories — DoS in Server Components / App Router / Cache Components, middleware & proxy bypass, SSRF on WebSocket upgrades, XSS in CSP nonces and `beforeInteractive`, image-optimization DoS, RSC cache poisoning. Plus closes `postcss<8.5.10` XSS (GHSA-qx2v-qp2m-jg93) by re-resolving the existing `^8.5.13` override.

## What changes (within existing semver ranges)
| Package | Before | After |
|---|---|---|
| `next` | `16.2.4` | `16.2.6` |
| `@next/mdx` | `^16.2.4` | `^16.2.6` |
| `eslint-config-next` | `^16.2.4` | `^16.2.6` |
| `react` | `19.2.5` | `19.2.6` |
| `react-dom` | `19.2.5` | `19.2.6` |
| `postcss` (transitive) | `8.5.9 / 8.4.31` | `8.5.14` (override re-applied) |

## Verification (run locally on commit `4791cb2` before the push split)
- `npm audit` → **0 vulnerabilities**
- `npm test` → **1/1 passing**
- `npm run lint` → **clean**
- `npm run build` → **success** (Next.js 16.2.6, all 6 pages generated)

## ⚠️ Lockfile not yet on this PR
The local `git-receive-pack` proxy is returning persistent HTTP 503 (4 retries with 2/4/8/16s backoff per protocol all failed; 5+ additional attempts also failed; verbose trace confirms `info/refs` returns 200 but the POST upload-pack endpoint is what's down). The 442KB `package-lock.json` exceeds the GitHub Contents API per-call content limit, so it can't ride alongside `package.json` via the API fallback either.

The follow-up commit `850a277` containing the lockfile diff is **ready locally** and will be pushed as soon as the proxy recovers. **Do not merge this PR until that commit lands** — `npm ci` will fail without the lockfile update because the resolved tree wouldn't match.

If you want to land it sooner: `git pull --rebase` against this branch on a healthy network, then `git push` (the local commit `850a277` will go up).

## Test plan
- [ ] Lockfile follow-up commit pushed (currently `850a277` local-only)
- [ ] CI green on the full branch
- [ ] `npm audit` reports 0 vulnerabilities post-merge
- [ ] No `postcss < 8.5.10` resolves anywhere in the lockfile
- [ ] #26 (eslint-plugin-react-hooks major bump) reviewed separately

---
_Generated by [Claude Code](https://claude.ai/code/session_016MTu3RtDxguNTjFMqoD6ud)_