### PR TITLE
chore(deps): patch/minor bumps — @types/node, tailwindcss, postcss (2026-05-17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,14 +26,14 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.40",
+        "@types/node": "^20.19.41",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.6",
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.1",
-        "tailwindcss": "^4.2.4",
+        "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3"
       }
     },
@@ -2899,9 +2899,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
-      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.40",
+    "@types/node": "^20.19.41",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.6",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "tailwindcss": "^4.2.4",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "postcss": "^8.5.13"
+    "postcss": "^8.5.14"
   }
 }


### PR DESCRIPTION
## Summary

Routine patch/minor freshness bumps from the 2026-05-17 audit (#41).

| Package | Before | After | Bump |
|---|---|---|---|
| `@types/node` | `^20.19.40` | `^20.19.41` | patch (in-range) |
| `tailwindcss` | `^4.2.4` | `^4.3.0` | minor |
| `postcss` (override) | `^8.5.13` | `^8.5.14` | patch |

`npm audit` reports **0 vulnerabilities** before and after (784 deps scanned).

Major-version bumps that surfaced in the audit (`eslint` 9→10, `eslint-plugin-react-hooks` 5→7, `typescript` 5→6, `@types/node` 20→25) are intentionally **not** included here — they remain pending approval in #33, #34, #36, #37, and #40.

## Test plan

- [x] `npm install` resolves cleanly, no peer-dep warnings
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm run lint` clean locally
- [x] `npm test` (jest) green locally — 1 passed, 1 total
- [x] `npx tsc --noEmit` clean locally
- [ ] CI green on this PR

Closes #41.

https://claude.ai/code/session_01Q4cERRL1cU8wCTmzYm7u69

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q4cERRL1cU8wCTmzYm7u69)_