### PR TITLE
chore(deps): bump @types/node 20.19.40 -> 20.19.41 (patch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.40",
+        "@types/node": "^20.19.41",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
@@ -2899,9 +2899,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
-      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.40",
+    "@types/node": "^20.19.41",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary

Auto-applied patch bump from the dependency audit in #43.

- `@types/node` ^20.19.40 → ^20.19.41 (types-only patch)
- `package-lock.json` regenerated

`npm audit` reports **0 vulnerabilities**. Jest suite (1 passed) green.

## Held for approval (not in this PR)

The audit also surfaced four **major** bumps that need a human go-ahead — see #43 for the proposed plan:

- `@types/node` 20 → 25
- `eslint` 9 → 10
- `eslint-plugin-react-hooks` 5 → 7
- `typescript` 5 → 6

## Test plan
- [x] `npm install` regenerates lock cleanly
- [x] `npm audit` → 0 vulnerabilities
- [x] `npm test` (jest) → all green
- [ ] CI passes on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_011YR6fEwRnYJapdtVb3hYAL)_