### PR TITLE
chore(deps): fix GHSA-58qx-3vcg-4xpx (ws) + @types/node patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.40",
+        "@types/node": "^20.19.41",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.39.4",
@@ -2899,9 +2899,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.40",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.40.tgz",
-      "integrity": "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q==",
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12305,9 +12305,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20.19.40",
+    "@types/node": "^20.19.41",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.39.4",


### PR DESCRIPTION
## Summary

Closes the only finding from the 2026-05-19 routine package audit (tracked in #45):

- **Security fix**: `ws` 8.20.0 → 8.20.1 via `npm audit fix` — resolves [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (moderate, CWE-908, uninitialized memory disclosure). Transitive through `jest-environment-jsdom > jsdom > ws`; dev-only.
- **Patch bump**: `@types/node` `^20.19.40` → `^20.19.41`.

No direct-dep major bumps in this PR — those (`eslint` 9→10, `eslint-plugin-react-hooks` 5→7, `typescript` 5→6) require approval and are being scoped separately.

## Verification

| Gate | Result |
|---|---|
| `npm audit` | `found 0 vulnerabilities` |
| `npm test` (jest) | ✅ 1 suite, 1 test |
| `npm run lint` (eslint) | ✅ clean |
| `npm run build` (next build) | ✅ static pages generated |

## Test plan

- [x] `npm audit` clean post-fix
- [x] Jest suite passes
- [x] ESLint clean
- [x] `next build` succeeds
- [ ] CI green on the PR

Refs #45


---
_Generated by [Claude Code](https://claude.ai/code/session_01HvHAJUbXtwusbC4EnL1j5V)_