### PR TITLE
security(deps): bump transitive ws 8.20.0 → 8.20.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12305,9 +12305,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Lockfile-only patch bump of the transitive `ws` dependency to clear a moderate npm audit advisory.

| Field | Value |
|---|---|
| Advisory | [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) — ws: Uninitialized memory disclosure |
| Severity | Moderate (CVSS 4.4) |
| Before | `ws@8.20.0` |
| After | `ws@8.20.1` |
| Path | `jest-environment-jsdom → jsdom → ws ^8.18.0` (devDependency only) |
| Files changed | `package-lock.json` only |

Closes #47.

## Verification

- `npm audit` → **found 0 vulnerabilities** ✅
- `npm test` → 1 suite, 1 test passed ✅
- `npm run lint` → clean ✅
- `package.json` unchanged ✅

## Test plan

- [x] `npm audit` clean
- [x] `npm test` passes
- [x] `npm run lint` passes
- [ ] CI green


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMV8WX3WgrEZtZMe6D74oD)_