### PR TITLE
chore: upgrade TypeScript to 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "jest-environment-jsdom": "^30.4.1",
         "tailwindcss": "^4.3.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -12047,9 +12047,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "jest-environment-jsdom": "^30.4.1",
     "tailwindcss": "^4.3.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.3"
+    "typescript": "^6.0.3"
   },
   "overrides": {
     "postcss": "^8.5.14",


### PR DESCRIPTION
## Summary

Upgrades TypeScript from 5.9 to 6.0.3.

## Compatibility

TypeScript 6 is the latest compatible major for the current TypeScript-ESLint toolchain. TypeScript 7 is intentionally deferred because the installed TypeScript-ESLint release supports TypeScript below 6.1.

## Validation

- `npm ci`
- `npm audit` — 0 vulnerabilities
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` — 1/1 passed
- `npm run build`