### PR TITLE
ci: enforce quality gates on master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:
@@ -26,5 +26,11 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Run type check
+        run: npm run typecheck
+
       - name: Run tests with coverage
         run: npm run test:coverage
+
+      - name: Build production app
+        run: npm run build

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,15 @@
 import type { NextConfig } from "next";
 import createMDX from "@next/mdx";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const projectRoot = dirname(fileURLToPath(import.meta.url));
 
 const nextConfig: NextConfig = {
   pageExtensions: ["js", "jsx", "md", "mdx", "ts", "tsx"],
+  turbopack: {
+    root: projectRoot,
+  },
 };
 
 const withMDX = createMDX({

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"


### PR DESCRIPTION
## Summary

- run CI for pull requests and pushes to the repository's actual default branch, `master`
- add a reusable `typecheck` command and gate it in CI
- build the production app in CI
- set Turbopack's root explicitly so lockfiles outside the project cannot break builds

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`
- `npm run build`

Closes #84.