### PR TITLE
test: enforce lint and coverage baseline

### DIFF
--- a/__tests__/components/ThemeSwitcher.test.tsx
+++ b/__tests__/components/ThemeSwitcher.test.tsx
@@ -1,17 +1,35 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useTheme } from 'next-themes';
 import { ThemeSwitcher } from '@/components/ThemeSwitcher';
 
-// Mock next-themes
+const setTheme = jest.fn();
+
 jest.mock('next-themes', () => ({
-  useTheme: () => ({
-    theme: 'terminal',
-    setTheme: jest.fn(),
-  }),
+  useTheme: jest.fn(),
 }));
 
 describe('ThemeSwitcher', () => {
-  it('renders correctly', () => {
+  const mockUseTheme = jest.mocked(useTheme);
+
+  beforeEach(() => {
+    setTheme.mockReset();
+  });
+
+  it.each([
+    ['terminal', 'Terminal Theme'],
+    ['cyberpunk', 'Cyberpunk Theme'],
+    ['retro', 'Retro Theme'],
+  ])('renders and switches to the %s theme', (theme, buttonTitle) => {
+    mockUseTheme.mockReturnValue({
+      theme,
+      setTheme,
+      themes: ['terminal', 'cyberpunk', 'retro'],
+    });
+
     render(<ThemeSwitcher />);
     expect(screen.getByText('SYS_ADMIN')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle(buttonTitle));
+    expect(setTheme).toHaveBeenCalledWith(theme);
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "coverage/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,15 @@ const createJestConfig = nextJest({
 // Add any custom config to be passed to Jest
 const config: Config = {
   coverageProvider: 'v8',
+  collectCoverageFrom: ['src/components/ThemeSwitcher.tsx'],
+  coverageThreshold: {
+    global: {
+      branches: 100,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
   testEnvironment: 'jsdom',
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint",
+    "lint": "eslint . --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:watch": "jest --watch",


### PR DESCRIPTION
## Summary

- lint the complete project and fail on warnings
- ignore generated coverage output during linting
- exercise every theme-switch action in the component test
- enforce 100% coverage for the explicitly scoped `ThemeSwitcher` baseline

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:coverage`
- `npm run build`

Closes #85.